### PR TITLE
Fixed missing "" on init.rhai file

### DIFF
--- a/template/init.rhai
+++ b/template/init.rhai
@@ -5,8 +5,8 @@ if variable::get("is_init") {
 		print();
 		print("*** Add the following statements to your build.rs:");
 		print();
-    	print(println!("cargo:rerun-if-changed={}", commitment_issues::find_valid_git_root!()););
-		print(#[cfg(not(target_os = "macos"))]);
+    	print("println!(\"cargo:rerun-if-changed={}\", commitment_issues::find_valid_git_root!());");
+		print("#[cfg(not(target_os = \"macos\"))]");
 		print("println!(\"cargo:rustc-link-arg=-Tmetadata.x\");");
 		print();
 	}


### PR DESCRIPTION

# Description
Hellooooo,

There seems to be a missing set of "" that prevents cargo-generate from working. This MR aims to add the missing quotes.


## Type of change

Please Tick the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran locally using cargo generate for https://github.com/ScottGibb/HC-SR501-Node-Red-Presence-Detector

### Your Specific Test Case
See above ^
## Checklist

- [x] My code follows the style guidelines of this project (this should be caught by the CI)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (this should be caught by the CI)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
