### PR TITLE
fix init.rhai by adding quote marks

### DIFF
--- a/template/init.rhai
+++ b/template/init.rhai
@@ -5,8 +5,8 @@ if variable::get("is_init") {
 		print();
 		print("*** Add the following statements to your build.rs:");
 		print();
-    	print(println!("cargo:rerun-if-changed={}", commitment_issues::find_valid_git_root!()););
-		print(#[cfg(not(target_os = "macos"))]);
+    	print("println!(\"cargo:rerun-if-changed={}\", commitment_issues::find_valid_git_root!());");
+		print("#[cfg(not(target_os = \"macos\"))]");
 		print("println!(\"cargo:rustc-link-arg=-Tmetadata.x\");");
 		print();
 	}


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please Tick the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Create a Rust project
`esp-generate`
Add the modified version of commitment issues
`cargo add --git https://github.com/tom-flaherty/commitment-issues`
Use cargo generate with the modified repo. There script should ask questions about the repo, so there should not be any message such as 'Failed executing script: init.rhai'
`cargo generate -g https://github.com/tom-flaherty/commitment-issues --init`

### Your Specific Test Case

## Checklist

- [x] My code follows the style guidelines of this project (this should be caught by the CI)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings (this should be caught by the CI)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
